### PR TITLE
ostree: adaption for boot partition

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -222,6 +222,7 @@ IMAGE_CMD_ostree () {
 	cat ${IMAGE_MANIFEST} | cut -d " " -f1,3 > usr/package.manifest
 
 	# add the required mount
+	echo "LABEL=otaboot     /boot    auto   defaults 0 0" >>usr/etc/fstab
         if [ -n "${GRUB_UESD}" ]; then
 	    echo "LABEL=otaefi     /boot/efi    auto   defaults 0 0" >>usr/etc/fstab
         fi

--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -88,6 +88,15 @@ while [ 1 ] ; do
     break
 done
 
+while [ 1 ] ; do
+    mount "LABEL=otaboot" /sysroot/boot || {
+        log_info "Mounting boot partition failed, waiting 0.1s for the device to be available..."
+        sleep 0.1
+        continue
+    }
+    break
+done
+
 killall -q udevd || true
 
 ostree-prepare-root /sysroot

--- a/recipes-sota/ostree/files/0001-create-boot-symlink-based-on-relative-path.patch
+++ b/recipes-sota/ostree/files/0001-create-boot-symlink-based-on-relative-path.patch
@@ -1,0 +1,32 @@
+From 454bc12500a6ddad9f5ade56dd1eaff3aeb8289a Mon Sep 17 00:00:00 2001
+From: Yunguo Wei <yunguo.wei@windriver.com>
+Date: Sat, 5 May 2018 17:49:06 +0800
+Subject: [PATCH] create boot symlink based on relative path
+
+If /boot is a seperated boot partition, grub will set root device to
+boot partition and an abs path doesn't make senese.
+
+Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>
+---
+ src/boot/grub2/ostree-grub-generator | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/boot/grub2/ostree-grub-generator b/src/boot/grub2/ostree-grub-generator
+index 4539ee7..0ebe113 100644
+--- a/src/boot/grub2/ostree-grub-generator
++++ b/src/boot/grub2/ostree-grub-generator
+@@ -91,9 +91,9 @@ populate_menu()
+         menu="${menu}\t initrd ${boot_prefix}${initrd}\n"
+         menu="${menu}}\n\n"
+ 
+-        linux_dir=`dirname ${boot_prefix}${linux}`
++        linux_dir=`dirname ${linux}`
+         boots[$count]=`mktemp -d ${sysroot_dir}${boot_prefix}/boot.XXXXXXXXXX`
+-        ln -sf ${linux_dir} ${boots[$count]}/boot
++        ln -sf ..${linux_dir} ${boots[$count]}/boot
+         ln -sf ../..${ostree} ${boots[$count]}/ostree
+         count=`expr $count + 1`
+     done
+-- 
+2.7.4
+

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -16,6 +16,7 @@ SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master \
            file://0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch \
            file://ostree_swap_bootentry_atomically.patch \
 	   file://using-bash-specifically.patch \
+	   file://0001-create-boot-symlink-based-on-relative-path.patch \
 	"
 
 


### PR DESCRIPTION
To support encrypted rootfs, we need to split /boot into a seperated
boot partition, which involves some adaption in ostree.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>