### PR TITLE
ostree:uboot:add non-default for bootdirs to uEnv.txt

### DIFF
--- a/recipes-sota/ostree/files/0003-uboot-add-non-default-for-bootdirs-to-uEnv.txt.patch
+++ b/recipes-sota/ostree/files/0003-uboot-add-non-default-for-bootdirs-to-uEnv.txt.patch
@@ -1,0 +1,28 @@
+From 854e0a1849c99fe00b53c1bfdfdd493f893bddc7 Mon Sep 17 00:00:00 2001
+From: Jiang Lu <lu.jiang@windriver.com>
+Date: Fri, 25 May 2018 13:00:47 +0800
+Subject: [PATCH] uboot: add non-default for bootdirs to uEnv.txt
+
+Add index for non-default bootdirs in uEnv.txt.
+
+Signed-off-by: Jiang Lu <lu.jiang@windriver.com>
+---
+ src/libostree/ostree-bootloader-uboot.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
+index 9ecc66f..5522943 100644
+--- a/src/libostree/ostree-bootloader-uboot.c
++++ b/src/libostree/ostree-bootloader-uboot.c
+@@ -138,7 +138,7 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
+       g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image%s=%s", index_suffix, val));
+ 
+       bootdir = strndup (val, strrchr(val, '/') - val);
+-      g_ptr_array_add (new_lines, g_strdup_printf ("bootdir=%s/", bootdir));
++      g_ptr_array_add (new_lines, g_strdup_printf ("bootdir%s=%s/", index_suffix, bootdir));
+ 
+       val = ostree_bootconfig_parser_get (config, "initrd");
+       if (val)
+-- 
+2.7.4
+

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -15,6 +15,7 @@ SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master \
            file://0001-ostree-secure-boot-support-for-no-change-to-grub.cfg.patch \
            file://0001-Allow-updating-files-in-the-boot-directory.patch  \
            file://0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch \
+           file://0003-uboot-add-non-default-for-bootdirs-to-uEnv.txt.patch \
            file://ostree_swap_bootentry_atomically.patch \
 	   file://using-bash-specifically.patch \
 	   file://0001-create-boot-symlink-based-on-relative-path.patch \


### PR DESCRIPTION
Add non-default for bootdirs to uEnv.txt

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>