### PR TITLE
util-linux bbappend: fix QA WARNING

### DIFF
--- a/recipes-core/util-linux/util-linux_%.bbappend
+++ b/recipes-core/util-linux/util-linux_%.bbappend
@@ -16,4 +16,4 @@ do_install_append () {
     fi
 }
 
-
+ALTERNATIVE_${PN}_remove = "nologin"


### PR DESCRIPTION
...
|WARNING: util-linux-2.30-r0 do_package: util-linux: alternative target (/usr/sbin/nologin
or /usr/sbin/nologin.util-linux) does not exist, skipping...
...

Since nologin is not used at usrmerge, remove it from update-alternatives

Issue: LINPULLT17-330

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>