### PR TITLE
ostree:deploy:using /etc in runtime as merge source

### DIFF
--- a/recipes-sota/ostree/files/0001-deploy-using-etc-in-runtime-as-merge-source.patch
+++ b/recipes-sota/ostree/files/0001-deploy-using-etc-in-runtime-as-merge-source.patch
@@ -1,0 +1,41 @@
+From f44f55e3c05aaa3d376375b7297a3e45c964d4e6 Mon Sep 17 00:00:00 2001
+From: Jiang Lu <lu.jiang@windriver.com>
+Date: Thu, 28 Jun 2018 16:29:45 +0800
+Subject: [PATCH] deploy:using /etc in runtime as merge source
+
+When deploy new ostree image, using /etc in runtime image as source for merge
+operation, instead of /etc in previouse image.
+
+For when upgrading a repo, user expected configuration in running system come
+into new ostree image.
+
+Signed-off-by: Jiang Lu <lu.jiang@windriver.com>
+---
+ src/libostree/ostree-sysroot-deploy.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
+index 5f5b1c1c..eb3351a3 100644
+--- a/src/libostree/ostree-sysroot-deploy.c
++++ b/src/libostree/ostree-sysroot-deploy.c
+@@ -443,7 +443,7 @@ merge_configuration_from (OstreeSysroot    *sysroot,
+ 
+   /* TODO: get rid of GFile usage here */
+   g_autoptr(GFile) orig_etc = ot_fdrel_to_gfile (merge_deployment_dfd, "usr/etc");
+-  g_autoptr(GFile) modified_etc = ot_fdrel_to_gfile (merge_deployment_dfd, "etc");
++  g_autoptr(GFile) modified_etc = g_file_new_for_path("/etc");
+   /* Return values for below */
+   g_autoptr(GPtrArray) modified = g_ptr_array_new_with_free_func ((GDestroyNotify) ostree_diff_item_unref);
+   g_autoptr(GPtrArray) removed = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+@@ -479,7 +479,7 @@ merge_configuration_from (OstreeSysroot    *sysroot,
+   if (!glnx_opendirat (merge_deployment_dfd, "usr/etc", TRUE, &orig_etc_fd, error))
+     return FALSE;
+   glnx_autofd int modified_etc_fd = -1;
+-  if (!glnx_opendirat (merge_deployment_dfd, "etc", TRUE, &modified_etc_fd, error))
++  if (!glnx_opendirat (-1, "/etc", TRUE, &modified_etc_fd, error))
+     return FALSE;
+   glnx_autofd int new_etc_fd = -1;
+   if (!glnx_opendirat (new_deployment_dfd, "etc", TRUE, &new_etc_fd, error))
+-- 
+2.14.3
+

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -23,6 +23,7 @@ SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master \
 	   file://0001-encrypt-decrypt-password-of-remote-repository-uri.patch \
 	   file://0001-tweak-regex-of-ostree-system-generator-for-pulsar.patch \
 	   file://0001-lib-repo-pull-Fix-free-function-for-hash-table.patch \
+	   file://0001-deploy-using-etc-in-runtime-as-merge-source.patch \
 	"
 
 


### PR DESCRIPTION
When deploy new ostree image, using /etc in runtime image as source for merge
operation, instead of /etc in previouse image.

For when upgrading a repo, user expected configuration in running system come
into new ostree image.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>